### PR TITLE
fix: verifySilent return type `String` -> `string`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ export function onDispatchingSignals(listener: (event: DispatchingSignalsStatus)
   return PreludeReactNativeSdkModule.addListener('onDispatchingSignals', listener);
 }
 
-export async function verifySilent(configuration: { sdk_key: string, request_url: string }): Promise<String> {
+export async function verifySilent(configuration: { sdk_key: string, request_url: string }): Promise<string> {
   return await PreludeReactNativeSdkModule.verifySilent(configuration.sdk_key, configuration.request_url);
 }
 


### PR DESCRIPTION
A typo `String` -> `string`