### PR TITLE
New release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Change Log
+
+Prelude React Native SDK Change Log
+
+## [0.3.3] - 2025-09-23
+
+- Update native components to Android version 0.2.3 and iOS version 0.2.4 which added Silent Verification support for Bouygues

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.library'
 
 group = 'so.prelude.reactnative.sdk'
-version = '0.2.2'
+version = '0.2.3'
 
 def expoModulesCorePlugin = new File(project(":expo-modules-core").projectDir.absolutePath, "ExpoModulesCorePlugin.gradle")
 apply from: expoModulesCorePlugin
@@ -44,5 +44,5 @@ android {
 
 dependencies {
   compileOnly('com.squareup.okhttp3:okhttp:4.12.0')
-  implementation('so.prelude.android:sdk:0.2.2')
+  implementation('so.prelude.android:sdk:0.2.3')
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prelude.so/react-native-sdk",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Prelude SDK for React Native",
   "main": "build/index.js",
   "types": "build/index.d.ts",
@@ -30,7 +30,8 @@
     "scripts/*",
     "src/*",
     "expo-module.config.json",
-    "tsconfig.json"
+    "tsconfig.json",
+    "CHANGELOG.md"
   ],
   "repository": "https://github.com/prelude-so/react-native-sdk",
   "bugs": {
@@ -53,6 +54,6 @@
     "react-native": "*"
   },
   "so_prelude": {
-    "apple_sdk_tag": "0.2.3"
+    "apple_sdk_tag": "0.2.4"
   }
 }


### PR DESCRIPTION
Update native components to Android version 0.2.3 and iOS version 0.2.4 which added Silent Verification support for Bouygues